### PR TITLE
Remove system:authenticated from groups as it makes the SCC eligible …

### DIFF
--- a/deploy/traefikee-scc.yaml
+++ b/deploy/traefikee-scc.yaml
@@ -18,8 +18,7 @@ allowedCapabilities:
 defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
-groups:
-- system:authenticated
+groups: []
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
 - MKNOD


### PR DESCRIPTION
`system:authenticated` makes many other pods eligible to be executed with this SCC. This creates many side-effect to theses pods execution ;-) 

Remove it and reserve it solely to the `default` service account of project where TraefikEE is installed.